### PR TITLE
Use temporary file system instead of volume

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -39,5 +39,5 @@ docker run \
     --read-only \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
-    --mount type=volume,dst=/tmp \
+    --tmpfs /tmp:exec \
     exercism/test-runner "${slug}" /solution /output 

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -21,7 +21,7 @@ docker run \
     --network none \
     --read-only \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
-    --mount type=volume,dst=/tmp \
+    --tmpfs /tmp:exec \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
     exercism/test-runner


### PR DESCRIPTION
The volume mount type for /tmp was a workaround, but with the latest version, this workaround is no longer needed.
