### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 RUN apk add --no-cache coreutils g++ libc-dev cmake make git boost-dev libtbb-dev
 

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -31,8 +31,13 @@ for test_dir in tests/*; do
     #   -e "s~${test_dir_path}~/solution~g" \
     #   "${results_file_path}"
 
+    # Add trailing newlines. Ignore line numbers.
+    for i in "${results_file_path}" "${expected_results_file_path}"; do
+        sed 's/:\d\+:/:NN:/g' "${i}" "${i}" > "${i}.cleaned"
+    done
     echo "${test_dir_name}: comparing results.json to expected_results.json"
-    diff "${results_file_path}" "${expected_results_file_path}"
+    diff "${results_file_path}.cleaned" "${expected_results_file_path}.cleaned"
+    rm "${results_file_path}.cleaned" "${expected_results_file_path}.cleaned"
 
     if [ $? -ne 0 ]; then
         exit_code=1


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.